### PR TITLE
Make the extension module depend on a system package

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 - [X] package pure python + extension module using hatch + bazel + pybind11
 - [X] check that on ubuntu we can install and run the package correctly
-- [ ] add a system package dependency to the extension module
+- [X] add a system package dependency to the extension module
 - [ ] sensible error message if system package dependency (or bazel) not available
 - [ ] check that on windows and mac we get a sensible error message

--- a/src/hatch_bazel_and_pybind11/pybind_extension.cc
+++ b/src/hatch_bazel_and_pybind11/pybind_extension.cc
@@ -1,11 +1,14 @@
 #include <pybind11/pybind11.h>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 namespace py = pybind11;
 
 struct Foo {
   int x;
+  boost::uuids::uuid id;
 
-  Foo(int x) : x(x) {}
+  Foo(int x) : x(x), id(boost::uuids::random_generator()()) {}
 };
 
 PYBIND11_MODULE(pybind_extension, m) {
@@ -13,5 +16,6 @@ PYBIND11_MODULE(pybind_extension, m) {
 
   py::class_<Foo>(m, "Foo")
     .def(py::init<int>(), py::arg("x"))
-    .def_readwrite("x", &Foo::x);
+    .def_readwrite("x", &Foo::x)
+    .def_property_readonly("id", [](const Foo& f) { return to_string(f.id); });
 }

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -8,3 +8,6 @@ from hatch_bazel_and_pybind11 import Foo
 def test_bazel_hatch_integration():
     f = Foo(x=42)
     assert f.x == 42
+
+    assert isinstance(f.id, str)
+    assert len(f.id) == len("07482dd2-25bf-4b4b-8a6b-b8ba285bc75f")


### PR DESCRIPTION
To complicate things, let's say the C++ code depends on system libraries, or in general other libraries that are NOT brought in via Bazel but are picked up from the system.